### PR TITLE
add frontend for entrant waitlist (no DB access)

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/EntrantRole.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/EntrantRole.java
@@ -3,6 +3,7 @@ package com.example.pickme_nebula0.entrant;
 import com.example.pickme_nebula0.event.Event;
 import com.example.pickme_nebula0.user.User;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -39,6 +40,11 @@ public class EntrantRole extends User {
     public void setEntrantID(String entrantID) {
         this.entrantID = entrantID;
     }
+
+
+    // GETTERS
+    public ArrayList<Event> getEventsInWaitlist() { return this.eventsInWaitlist;}
+    public ArrayList<Event> getEventsEnrolled() { return this.eventsEnrolled;}
 
     //------------ GET STATUS OF EVENTS
 

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistContentFragment.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistContentFragment.java
@@ -14,6 +14,7 @@ import com.example.pickme_nebula0.event.Event;
 import com.example.pickme_nebula0.event.WaitlistEventAdapter;
 
 import java.util.ArrayList;
+import java.util.Date;
 
 public class EntrantWaitlistContentFragment extends Fragment {
 
@@ -49,8 +50,6 @@ public class EntrantWaitlistContentFragment extends Fragment {
                     eventTitles[i],
                     eventDescriptions[i],
                     null,
-                    "",
-                    "",
                     false,
                     0,
                     false,

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistContentFragment.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistContentFragment.java
@@ -1,0 +1,71 @@
+package com.example.pickme_nebula0.entrant.fragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
+
+import androidx.fragment.app.Fragment;
+
+import com.example.pickme_nebula0.R;
+import com.example.pickme_nebula0.entrant.EntrantRole;
+import com.example.pickme_nebula0.event.Event;
+import com.example.pickme_nebula0.event.WaitlistEventAdapter;
+
+import java.util.ArrayList;
+
+public class EntrantWaitlistContentFragment extends Fragment {
+
+    private EntrantRole entrant;
+    private ListView eventList;
+    private ArrayList<Event> dataList;
+    private WaitlistEventAdapter waitlistEventAdapter;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        // fragment_entrant_waitlist.xml
+        View rootView = inflater.inflate(R.layout.fragment_entrant_waitlist_content, container, false);
+
+        // TESTING SETUP
+        this.entrant = new EntrantRole(
+                "somedeviceID", "entrantname", "e@mail.com",
+                "1234567890", ""
+        );
+
+        // sample data
+        // TODO: remove
+        String[] eventTitles = {"Event 1", "Event 2", "Event 3"};
+        String[] eventDescriptions = {
+                "Description for Event 1", "Description for Event 2", "Description for Event 3"
+        };
+        int[] eventCapacity = {10, 20, 30};
+        int[] waitingListCapacity = {11, 21, 31};
+
+        // initialize data list
+        for (int i = 0; i < eventTitles.length; i++) {
+            // create new event
+            Event eventToAdd = new Event(
+                    eventTitles[i],
+                    eventDescriptions[i],
+                    null,
+                    "",
+                    "",
+                    false,
+                    0,
+                    false,
+                    eventCapacity[i],
+                    waitingListCapacity[i]
+            );
+            // add event to entrant role
+            entrant.joinWaitlist(eventToAdd);
+        }
+
+        // initialize listview and adapter
+        eventList = rootView.findViewById(R.id.entrant_waitlist_content_list);
+        waitlistEventAdapter = new WaitlistEventAdapter(getActivity(),  entrant.getEventsInWaitlist());
+        eventList.setAdapter(waitlistEventAdapter);
+
+        return rootView;
+    }
+}

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistFragment.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/entrant/fragments/EntrantWaitlistFragment.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
 
 import com.example.pickme_nebula0.R;
 
@@ -19,8 +20,19 @@ public class EntrantWaitlistFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.fragment_entrant_waitlist, container, false);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        // fragment_entrant_waitlist.xml
+        View rootView = inflater.inflate(R.layout.fragment_entrant_waitlist, container, false);
+
+        // update entrant_waitlist_content_activity FragmentContainerView
+        // in fragment_entrant_waitlist.xml
+        FragmentTransaction transaction = getParentFragmentManager().beginTransaction();
+        EntrantWaitlistContentFragment fragment = new EntrantWaitlistContentFragment();
+        transaction.replace(R.id.entrant_waitlist_content_activity, fragment);
+
+        // Commit the transaction
+        transaction.commit();
+
+        return rootView;
     }
 }

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/WaitlistEventAdapter.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/WaitlistEventAdapter.java
@@ -1,0 +1,73 @@
+package com.example.pickme_nebula0.event;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+
+import com.example.pickme_nebula0.R;
+
+import java.util.ArrayList;
+
+public class WaitlistEventAdapter extends ArrayAdapter<Event> {
+
+    private CardView eventCardView;
+    private LinearLayout expandableLayout;
+
+    public WaitlistEventAdapter(Context context, ArrayList<Event> events) {
+        super(context, 0, events);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view;
+
+        if (convertView == null) {
+            view = LayoutInflater.from(getContext()).inflate(R.layout.fragment_list_event, parent, false);
+        }
+        else {
+            view = convertView;
+        }
+
+        Event event = getItem(position);
+        TextView eventName = view.findViewById(R.id.event_name);
+        TextView eventDescription = view.findViewById(R.id.event_description);
+
+        eventName.setText(event.getEventName());
+        eventDescription.setText(event.getEventDescription());
+
+        Log.d("ListEventCreation", "Calling ListEventFragment");
+
+        // Get references to the CardView and the hidden LinearLayout
+        this.eventCardView = view.findViewById(R.id.event_card_view);
+        this.expandableLayout = view.findViewById(R.id.event_hidden_view);
+
+        // Set an OnClickListener on the CardView
+        Log.d("ListEventFragment", "Setting OnClickListener for CardView");
+        eventCardView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Log.d("ListEventFragment", "CardView clicked");
+                // Toggle the visibility of the expandable content
+                if (expandableLayout.getVisibility() == View.GONE) {
+                    // Show the expandable content
+                    expandableLayout.setVisibility(View.VISIBLE);
+                } else {
+                    // Hide the expandable content
+                    expandableLayout.setVisibility(View.GONE);
+                }
+            }
+        });
+
+        return view;
+    };
+}

--- a/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist.xml
+++ b/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/entrant_waitlist_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
 
-    <TextView
-        android:id="@+id/entrant_waitlist_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Waitlist Content"
-        android:layout_gravity="center" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/entrant_waitlist_content_activity"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </FrameLayout>

--- a/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist_content.xml
+++ b/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist_content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="16dp">
@@ -9,7 +10,7 @@
         android:id="@+id/entrant_waitlist_content_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1">
+        app:layout_constraintBottom_toBottomOf="parent">
 
     </ListView>
 

--- a/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist_content.xml
+++ b/app/PickMe_nebula0/app/src/main/res/layout/fragment_entrant_waitlist_content.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <ListView
+        android:id="@+id/entrant_waitlist_content_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+    </ListView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/PickMe_nebula0/app/src/main/res/layout/fragment_list_event.xml
+++ b/app/PickMe_nebula0/app/src/main/res/layout/fragment_list_event.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <!-- CardView for the expandable card -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/event_card_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="4dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:clickable="true"
+        android:focusable="true">
+
+        <!-- Main content layout within the CardView -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <!-- Title section that will always be visible -->
+            <TextView
+                android:id="@+id/event_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="event - default name"
+                android:textSize="18sp"
+                android:textColor="@android:color/black"
+                android:fontFamily="sans-serif-medium" />
+
+            <!-- Expandable content (initially hidden) -->
+            <LinearLayout
+                android:id="@+id/event_hidden_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="visible"
+                android:paddingTop="8dp">
+
+                <TextView
+                    android:id="@+id/event_description"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="event - default description"
+                    android:textSize="16sp"
+                    android:textColor="@android:color/black" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
adds frontend sample for the `waitlist` underneath `entrant`.

Changed: `EntrantWaitlistFragment.java`
Logic for `entrant_waitlist.xml`

Changed: `fragment_entrant_waitlist.xml`
Layout that contains everything created when `EntrantWaitlistFragment.java` is called by `EntrantHomeActivity.java`. Currently contains a `FragmentView`

Added: `EntrantWaitlistContentFragment.java`
Logic for `entrant_waitlist_content.xml`. This Fragment file fills the `FragmentView` in `entrant_waitlist.xml`

Added: `fragment_entrant_waitlist_content.xml`
Layout that contains a `ListView`. This `ListView` will be a list of waitlisted `Events`

Added: `fragment_list_event.xml`
Layout for each item that appears in the `ListView` for `fragment_entrant_waitlist_content.xml`. This is for *waitlisted* `Events` only.

Changed: `EntrantRole.java`
Added Getters to get the *waitlisted* and *enrolled* events for a `User`.

Added: `WaitlistEventAdapter.java`
Connects `Events.java` (functionality) to `fragment_list_event.xml` (layout list item).