### PR TITLE
Sampling and Resampling Functionality

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/DBManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/DBManager.java
@@ -2,6 +2,8 @@ package com.example.pickme_nebula0.db;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Base64;
 import android.util.Log;
 
@@ -25,6 +27,7 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -596,7 +599,7 @@ public class DBManager {
 
         waitlistedUsersQuery.get().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
-                ArrayList<User> waitlistedUsers = new ArrayList<>();
+                List<User> waitlistedUsers = Collections.synchronizedList(new ArrayList<>());
 
                 for (QueryDocumentSnapshot registeredUserDoc : task.getResult()) {
                     String userID = registeredUserDoc.getId();
@@ -606,13 +609,10 @@ public class DBManager {
                         final CompletableFuture<User> userFuture = new CompletableFuture<>();
 
                         // fetch actual event asynchronously
-                        getUser(userID, (userFetched) -> {
-                            userFuture.complete((User) userFetched);
-                        }, () -> {
+                        getUser(userID, (userFetched) -> { userFuture.complete((User) userFetched);}, () -> {
                             Log.d("Firestore", "Could not get registered user " + userID);
                             userFuture.completeExceptionally(new Exception("Failed to fetch waitlisted user"));
                         });
-
                         return userFuture.get();
                     });
 
@@ -629,6 +629,12 @@ public class DBManager {
                     } catch (Exception e) {
                         Log.d("Firestore", "Error while fetching users: " + e.getMessage());
                     } finally {
+                        synchronized (waitlistedUsers) {
+                            new Handler(Looper.getMainLooper()).post(() -> {
+                                onSuccessCallback.run((List<User>) waitlistedUsers);
+                                Log.d("Firestore", "waitlisted users callback was invoked with size: " + waitlistedUsers.size());
+                            });
+                        }
                         executor.shutdown();
                         try {
                             if (!executor.awaitTermination(800, TimeUnit.MILLISECONDS)) {
@@ -637,8 +643,6 @@ public class DBManager {
                         } catch (InterruptedException e) {
                             executor.shutdownNow();
                         }
-
-                        onSuccessCallback.run(waitlistedUsers);
                     }
                 });
             } else {

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/DBManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/DBManager.java
@@ -330,7 +330,7 @@ public class DBManager {
      * @param userID deviceID of user we are sending the notification to
      * @param eventID ID of event associated with notification
      */
-    private void createNotification(String title, String message, String userID, String eventID){
+    public void createNotification(String title, String message, String userID, String eventID){
         CollectionReference userNotifCollection = db.collection(notificationCollection).document(userID).collection("userNotifs");
         String notifID = createIDForDocumentIn(userNotifCollection);
         Timestamp timestamp = new Timestamp(new Date());

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventDetailActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventDetailActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.util.Base64;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -17,9 +18,17 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.pickme_nebula0.R;
 import com.example.pickme_nebula0.db.DBManager;
 import com.example.pickme_nebula0.notification.NotificationCreationActivity;
+import com.example.pickme_nebula0.organizer.OrganizerRole;
 import com.example.pickme_nebula0.organizer.activities.OrganizerEventParticipantsActivity;
 import com.example.pickme_nebula0.DeviceManager;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.example.pickme_nebula0.user.User;
+
+import java.util.ArrayList;
+
+
+// NOTE: Assumes that if there is at least one selected entrant present,
+// first sampling has already occurred.
 
 public class EventDetailActivity extends AppCompatActivity {
 
@@ -28,10 +37,10 @@ public class EventDetailActivity extends AppCompatActivity {
     private ImageView qrCodeImageView;
     private Button participantsButton;
     private Button msgEntrantsButton;
+    private Button sampleEntrantsButton;
     private Button backButton;
 
     private String eventID;
-
     private DBManager dbManager;
 
     @Override
@@ -44,6 +53,7 @@ public class EventDetailActivity extends AppCompatActivity {
         // Initialize UI components
         backButton = findViewById(R.id.backButton);
         msgEntrantsButton = findViewById(R.id.button_ed_msgEntrants);
+        sampleEntrantsButton = findViewById(R.id.button_sample_entrants);
         participantsButton = findViewById(R.id.participantsButton);
         eventDetailsTextView = findViewById(R.id.event_details_text_view);
         qrCodeImageView = findViewById(R.id.qr_code_image_view);
@@ -51,7 +61,7 @@ public class EventDetailActivity extends AppCompatActivity {
         dbManager = new DBManager();
 
         // Retrieve eventID from intent
-        eventID = getIntent().getStringExtra("eventID");
+        String eventID = getIntent().getStringExtra("eventID");
 
         if (eventID == null || eventID.trim().isEmpty()) {
             Toast.makeText(this, "Invalid Event ID.", Toast.LENGTH_SHORT).show();
@@ -64,6 +74,12 @@ public class EventDetailActivity extends AppCompatActivity {
 
         // Fetch and display event details
         fetchEventDetails(eventID);
+
+        // Check if event has already sampled entrants
+        OrganizerRole.sampledEntrantsExist(eventID, () -> {
+            // rename text to resample entrants
+            sampleEntrantsButton.setText("Resample Entrants");
+        }, () -> {});
     }
 
     /**
@@ -85,6 +101,27 @@ public class EventDetailActivity extends AppCompatActivity {
             Intent intent = new Intent(EventDetailActivity.this, NotificationCreationActivity.class);
             intent.putExtra("eventID", eventID);
             startActivity(intent);
+        });
+
+        // Sample Entrants Button
+        sampleEntrantsButton.setOnClickListener(v -> {
+            OrganizerRole.sampledEntrantsExist(eventID, () -> {
+                Log.d("EventDetailActivity", "RESAMPLING USERS");
+                // sampled entrants exist
+                // do resampling instead
+                OrganizerRole.resampleAndSelectUsers(eventID, (resampledUsersObj) -> {
+                    for (User user : ((ArrayList<User>) resampledUsersObj)) {
+                        Log.d("EventDetailActivity", "resampled user "+user.getUserID());
+                    }});
+            }, () -> {
+                Log.d("EventDetailActivity", "SAMPLING USERS");
+                // do first sampling
+                OrganizerRole.sampleAndSelectUsers(eventID, (selectedUsersObj) -> {
+                    for (User user : ((ArrayList<User>) selectedUsersObj)) {
+                        Log.d("EventDetailActivity", "sampled user "+user.getUserID());
+                    }
+                });
+            });
         });
 
         // Participants Button

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
@@ -3,13 +3,20 @@ package com.example.pickme_nebula0.organizer;
 import android.util.Log;
 
 import com.example.pickme_nebula0.db.DBManager;
+import com.example.pickme_nebula0.db.DBManagerStatic;
 import com.example.pickme_nebula0.entrant.EntrantRole;
 import com.example.pickme_nebula0.event.Event;
 import com.example.pickme_nebula0.user.User;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Date;
+import java.util.List;
 
 /**
  * OrganizerRole
@@ -17,6 +24,10 @@ import java.util.Date;
 public class OrganizerRole extends User {
     private String organizerID;
     private ArrayList<Event> events = new ArrayList<Event>();
+
+    private static String usersSelectedKey = "selected";
+    private static String usersNotSelectedKey = "not selected";
+    private static String organizer_tag = "OrganizerRole";
 
     /**
      * Constructor
@@ -41,34 +52,39 @@ public class OrganizerRole extends User {
         this.organizerID = organizerID;
     }
 
+    // US 02.01.01 As a an organizer I want to create a new event and generate a unique promotional QR code that links to the event description and event poster in the app
+    // already implemented
     public boolean createEvent() {
 //        boolean eventCreated = false;
 //        // Create event
 //        Event event = new Event();
 //        events.add(event);
 //        //
-//        return false;
-        throw new RuntimeException("NOT IMPLEMENTED");
+        return false;
     }
 
+    // US 02.01.01 As a an organizer I want to create a new event and generate a unique promotional QR code that links to the event description and event poster in the app
     public boolean generateQRCode() {
         boolean QRCodeGenerated = false;
         // Generate QR code
         return false;
     }
 
+    // US 02.01.04 As an organizer I want to store hash data of the generated QR code in my database
     public boolean storeHashDataQRCode() {
         boolean hashDataStored = false;
         // Store hash data
         return false;
     }
 
+    // US 02.01.04 As an organizer I want to store hash data of the generated QR code in my database
     public boolean deleteHashDataQRCode() {
         boolean hashDataDeleted = false;
         // Delete hash data
         return false;
     }
 
+    // US 02.02.01 As an organizer I want to view the list of entrants who joined my event waiting list
     public ArrayList<EntrantRole> viewWaitlist(Event event) {
         ArrayList<EntrantRole> entrantsInWaitlist = new ArrayList<EntrantRole>();
 
@@ -76,69 +92,154 @@ public class OrganizerRole extends User {
         return entrantsInWaitlist;
     }
 
+    // US 02.02.02 As an organizer I want to see on a map where entrants joined my event waiting list from.
     public void viewMapOfWaitlist(Event event) {
         // in future, show the map of entrants who joined the event waiting list
     }
 
+    // US 02.03.01 As an organizer I want to OPTIONALLY limit the number of entrants who can join my waiting list
     public int getWaitlistCapacity(Event event) {
         return event.getWaitlistCapacity();
     }
 
+    // US 02.03.01 As an organizer I want to OPTIONALLY limit the number of entrants who can join my waiting list
     public void setWaitlistCapacity(Event event, int capacity) {
         event.setWaitlistCapacity(capacity);
     }
 
+    // US 02.04.01 As an organizer I want to upload an event poster to provide visual information to entrants 
     public String getEventPoster(Event event) {
         return event.getEventPoster();
     }
 
+    // US 02.04.01 As an organizer I want to upload an event poster to provide visual information to entrants 
     public void setEventPoster(Event event, String eventPoster) {
         event.setEventPoster(eventPoster);
     }
 
 
     /**
+     * US 02.05.02
+     * As an organizer I want to set the system to sample a specified number of attendees to register for the event
+     *
      * Samples all users in the waitlist, based on the event capacity of the given event,
      * or samples all if event capacity is none.
      * Sets their status to SELECTED and updates the corresponding EventRegistrants status.
      * Passes the list of selected users to onSuccessCallback (as an Object.)
-     * @param eventID eventID
-     * @param onSuccessCallback onSuccessCallback
+     * @param eventID
+     * @param onSuccessCallback
      */
     public static void sampleAndSelectUsers(String eventID, DBManager.Obj2VoidCallback onSuccessCallback) {
         DBManager dbManager = new DBManager();
+
         // get waitlist capacity first via event
         dbManager.getEvent(eventID, (eventObj) -> {
             Event event = (Event) eventObj;
             int eventCapacity = event.getEventCapacity();
 
-            // get random sample of users and add them to selected list
-            sampleUsers(eventID, eventCapacity, (userListObj) -> {
-                ArrayList<User> usersSelected = (ArrayList<User>) userListObj;
-                Log.d("TEST", String.format("Sampled %s users from event capacity %s", usersSelected.size(), eventCapacity));
+            // get random sample of users
+            sampleUsers(eventID, eventCapacity, (sampleResultsObj) -> {
+                HashMap<String, ArrayList<User>> sampleResults = (HashMap<String, ArrayList<User>>) sampleResultsObj;
 
+                ArrayList<User> usersSelected = sampleResults.get(usersSelectedKey);
+                ArrayList<User> usersNotSelected = sampleResults.get(usersNotSelectedKey);
+
+                Log.d(organizer_tag, java.lang.String.format("Sampled %s users from event capacity %s", usersSelected.size(), eventCapacity));
+
+                // update status of selected entrants and notify
                 for (User user : usersSelected) {
-                    Log.d("TEST", String.format("Sampled user %s for initial event selection", user.getName()));
+                    Log.d(organizer_tag, java.lang.String.format("Sampled user %s for initial event selection", user.getName()));
                     dbManager.setRegistrantStatus(eventID, user.getUserID(), DBManager.RegistrantStatus.SELECTED);
+                    notifyEntrantChosen(event, user);
+                }
 
-                    // possible race condition
-                    // consider calling from onSuccessCallback instead
-                    dbManager.notifyEntrantsOfStatus("Not Selected For Event",
-                            "You will remain waitlisted in case a spot opens up",
-                            eventID, DBManager.RegistrantStatus.WAITLISTED);
+                // notify entrants not sampled
+                for (User user : usersNotSelected) {
+//                    Log.d(organizer_tag, java.lang.String.format("Did not sample user %s for initial event selection", user.getName()));
+                    notifyEntrantNotChosen(event, user);
                 }
                 onSuccessCallback.run(usersSelected);
             });
 
-        }, () -> {Log.d("Firestore", "Could not fetch event to check event capacity.");});
+        }, () -> {Log.d(organizer_tag, "Could not fetch event to check event capacity.");});
     }
 
     /**
+     * US 02.05.03
+     * As an organizer I want to be able to draw a replacement applicant from the pooling system
+     * when a previously selected applicant cancels or rejects the invitation.
+     *
+     * Resample users whose status remains waitlisted by the number of free spots,
+     * which is the difference between the event capacity and number of selected users (if any.)
+     * Sets their status to SELECTED.
+     * Passes the list of resampled users to onSuccessCallback (as an Object.)
+     * @param eventID
+     * @param onSuccessCallback
+     */
+    public static void resampleAndSelectUsers(String eventID, DBManager.Obj2VoidCallback onSuccessCallback) {
+        // assumes that event capacity is defined, otherwise there would be no one to resample
+        // get event capacity and (number of entrants who were selected + confirmed entrants)
+        // the difference is the number of free spots to be filled by resampling
+        DBManager dbManager = new DBManager();
+
+        // get event capacity
+        dbManager.getEvent(eventID, (eventObj) -> {
+            Event event = (Event) eventObj;
+            int eventCapacity = event.getEventCapacity();
+//            assert(eventCapacity != -1);
+            if (eventCapacity == -1) {return;}
+
+            // get number of entrants who are selected and confirmed
+            countConfirmedAndSelected(eventID, (countObj) -> {
+                int count = (int) countObj;
+                int free_spots = eventCapacity - count;
+                Log.d(organizer_tag, String.format("Free spots %d = %d-%d", free_spots, eventCapacity, count));
+                if (free_spots > 0) {
+                    // resample by number of free spots
+                    sampleUsers(eventID, free_spots, (sampleResultsObj) -> {
+                        HashMap<String, ArrayList<User>> sampleResults = (HashMap<String, ArrayList<User>>) sampleResultsObj;
+
+                        ArrayList<User> usersResampled = sampleResults.get(usersSelectedKey);
+                        for (User user : usersResampled) {
+                            // set new status and notify
+                            dbManager.setRegistrantStatus(eventID, user.getUserID(), DBManager.RegistrantStatus.SELECTED);
+                            notifyEntrantResampled(event, user);
+                        }
+                        onSuccessCallback.run(usersResampled);
+                    });
+                } else { Log.d(organizer_tag, "No entrants to resample"); }
+            });
+            }, () -> {Log.d(organizer_tag, "failed to fetch event for resampling"); return;});
+    }
+
+    // cancel all users who are selected and did not accept their invite
+    public static void cancelUsers(String eventID, DBManager.Obj2VoidCallback onSuccessCallback) {
+        DBManager dbManager = new DBManager();
+
+        dbManager.getEvent(eventID, (eventObj) -> {
+            // load users registered in event
+            dbManager.loadUsersRegisteredInEvent(eventID, DBManager.RegistrantStatus.SELECTED, (selectedUsersObj) -> {
+                ArrayList<User> users = (ArrayList<User>) selectedUsersObj;
+                for (User user:users) {
+                    dbManager.setRegistrantStatus(eventID, user.getUserID(), DBManager.RegistrantStatus.CANCELED);
+                    notifyEntrantCancelled((Event) eventObj, user);
+                }
+            });
+
+        }, () -> {Log.d(organizer_tag, "Could not fetch event for cancelling users");});
+    }
+
+
+    /**
      * Utility function that randomly samples users registered for an event
-     * and passes this list to the onSuccessCallback (as an Object.)
-     * @param eventID eventID
-     * @param sampleNum sampleNum
-     * @param onSuccessCallback onSuccessCallback
+     * and passes sampled and not sampled users to the onSuccessCallback
+     * as a Hashmap typecasted to as an Object.
+     * The hashmap has the following keys:
+     *  usersSelectedKey
+     *  usersNotSelectedKey
+     * @param eventID
+     * @param sampleNum
+     * @param onSuccessCallback
      */
     public static void sampleUsers(String eventID, int sampleNum, DBManager.Obj2VoidCallback onSuccessCallback) {
         DBManager dbManager = new DBManager();
@@ -147,44 +248,31 @@ public class OrganizerRole extends User {
         // then shuffle and sample
         dbManager.loadAllUsersRegisteredInEvent(eventID, DBManager.RegistrantStatus.WAITLISTED,
                 (userListObj) -> {
-                    ArrayList<User> users = (ArrayList<User>) userListObj;
-                    ArrayList<User> usersToSelect = new ArrayList<>();
+                    ArrayList<User> users = new ArrayList<>((List<User>) userListObj);
+                    ArrayList<User> usersSelected = new ArrayList<>();
+                    ArrayList<User> usersNotSelected = new ArrayList<>();
 
                     if (sampleNum == -1 || users.size() <= sampleNum) {
-                        usersToSelect.addAll(users);
+                        usersSelected.addAll(users);
                     } else {
                         ArrayList<User> randomUsers = new ArrayList<>(users);
                         Collections.shuffle(randomUsers);
-                        usersToSelect = new ArrayList<>(randomUsers.subList(0, sampleNum));
+                        usersSelected = new ArrayList<>(randomUsers.subList(0, sampleNum));
+                        usersNotSelected = new ArrayList<>(randomUsers.subList(sampleNum, randomUsers.size()));
                     }
 
-                    onSuccessCallback.run(usersToSelect);
+                    HashMap<String, ArrayList<User>> samplingResult = new HashMap<>();
+                    samplingResult.put(usersSelectedKey, usersSelected);
+                    samplingResult.put(usersNotSelectedKey, usersNotSelected);
+
+                    onSuccessCallback.run(samplingResult);
 
                 });
     }
 
-    /**
-     * Resample users whose status remains waitlisted.
-     * Sets their status to SELECTED and updates the corresponding EventRegistrants status.
-     * Passes the list of resampled users to onSuccessCallback (as an Object.)
-     * @param eventID eventID
-     * @param resampleNum number of users to resample
-     * @param onSuccessCallback onSuccessCallback
-     */
-    public static void resampleAndSelectUsers(String eventID, int resampleNum, DBManager.Obj2VoidCallback onSuccessCallback) {
-        // assumes all entrants in waitlist elected to be resampled
-        DBManager dbManager = new DBManager();
-        sampleUsers(eventID, resampleNum, (userListObj) -> {
-            ArrayList<User> usersResampled = (ArrayList<User>) userListObj;
-            for (User user : usersResampled) {
-                dbManager.setRegistrantStatus(eventID, user.getUserID(), DBManager.RegistrantStatus.SELECTED);
-            }
-
-            onSuccessCallback.run(usersResampled);
-        });
-    }
 
 
+    // US 02.06.01 As an organizer I want to view a list of all chosen entrants who are invited to apply
     public ArrayList<EntrantRole> getInvitedEntrants(Event event) {
         return event.getEntrantsChosen();
     }
@@ -206,46 +294,96 @@ public class OrganizerRole extends User {
     }
 
     //---------- NOTIFICATIONS
+    // the following user stories are covered by notifyEntrantsByStatus in DBManager:
     // US 02.07.01 As an organizer I want to send notifications to all entrants on the waiting list
-    public boolean notifyEntrantsInWaitlist(Event event, String message) {
-        return notifyEntrants(event, event.getEntrantsInWaitlist(), message);
-    }
-
     // US 02.07.02 As an organizer I want to send notifications to all selected entrants
-    public boolean notifySelectedEntrants(Event event, String message) {
-        return notifyEntrants(event, event.getEntrantsChosen(), message);
-    }
-
     // US 02.07.03 As an organizer I want to send a notification to all canceled entrants
-    public boolean notifyCancelledEntrants(Event event, String message) {
-        return notifyEntrants(event, event.getEntrantsCancelled(), message);
+
+    public boolean notifyEntrantsByStatus(String eventID, String title, String message, DBManagerStatic.RegistrantStatus status) {
+        DBManagerStatic.notifyEntrantsOfStatus(title, message, eventID, status);
+        return true;
     }
 
     // US 02.05.01 As an organizer I want to send a notification to chosen entrants to sign up for events
-    public boolean notifyEntrantsChosen(Event event) {
-        String message = "You have been selected for "+event.getEventName()+". Sign up now.";
-        return notifyEntrants(event, event.getEntrantsChosen(), message);
+    // called for each selected entrant (sampled or resampled)
+    // defines title, message, and updates Notification documents
+    // function is for individual entrants because functions that list
+    // all users are callback functions and this makes the most sense
+    public static boolean notifyEntrantChosen(Event event, User user) {
+        if (!user.getNotificationsEnabled()) {return false;}
+        String title = "Selected For Event";
+        String message = "You have been selected to join the following event: " + event.getEventName();
+        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        return true;
     }
 
-    public boolean notifyEntrants(Event event, ArrayList<EntrantRole> entrants, String message) {
-        boolean notificationSent = false;
+    public static boolean notifyEntrantResampled(Event event, User user) {
+        if (!user.getNotificationsEnabled()) {return false;}
+        String title = "Selected For Event";
+        String message = "You have been selected to join the following event, since some have declined their invite: " + event.getEventName();
+        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        return true;
+    }
 
-        // notification attributes
-        Date timestamp = new Date();
-        String eventID = event.getEventID();
+    public static boolean notifyEntrantNotChosen(Event event, User user) {
+        if (!user.getNotificationsEnabled()) {return false;}
+        String title = "Not Selected For Event";
+        String message = "You have not been sampled for the following event, but you will remain waitlisted in case a spot opens up: " + event.getEventName();
+        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        return true;
+    }
 
-        for (int i=0; i<entrants.size(); i++) {
-            EntrantRole current_entrant = entrants.get(i);
+    public static boolean notifyEntrantCancelled(Event event, User user) {
+        if (!user.getNotificationsEnabled()) {return false;}
+        String title = "Cancelled Event Invite";
+        String message = "Your invitation to join the following event has been cancelled: " + event.getEventName();
+        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        return true;
+    }
 
-            if (current_entrant.canRecieveNotifs()) {
-                String entrantID = current_entrant.getUserID(); // replace with device ID
+    // -------------- UTILITY FUNCTIONS
+    public static void sampledEntrantsExist(String eventID, DBManagerStatic.Void2VoidCallback entrantsExistCallback, DBManagerStatic.Void2VoidCallback entrantsNotExistCallback) {
+        DBManager dbm = new DBManager();
+        CollectionReference eventRegistrantsRef = dbm.db.collection(dbm.eventsCollection)
+                .document(eventID)
+                .collection(dbm.eventRegistrantsCollection);
+        Task<QuerySnapshot> selectedQuery = eventRegistrantsRef.whereEqualTo(dbm.eventStatusKey, DBManager.RegistrantStatus.SELECTED).get();
+        selectedQuery.addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                QuerySnapshot querySnapshot = task.getResult();
+                int numSelected = querySnapshot.size();
 
-                // NOTIFICATION GOES HERE
-                // how to send notification?
-
+                if (numSelected > 0) {
+                    entrantsExistCallback.run();
+                } else {
+                    entrantsNotExistCallback.run();
+                }
+            } else {
+                Log.d(organizer_tag, "Error getting selected entrants: " + task.getException());
             }
-        }
+        });
+    }
 
-        return notificationSent;
+    // for resampling users
+    private static void countConfirmedAndSelected(String eventID, DBManagerStatic.Obj2VoidCallback onSuccessCallback) {
+        DBManager dbm = new DBManager();
+        // reference to EventRegistrants subcollection
+        CollectionReference eventRegistrantsRef = dbm.db.collection(dbm.eventsCollection)
+                .document(eventID)
+                .collection(dbm.eventRegistrantsCollection);
+
+        Task<QuerySnapshot> selectedQuery = eventRegistrantsRef.whereEqualTo(dbm.eventStatusKey, DBManager.RegistrantStatus.SELECTED).get();
+        Task<QuerySnapshot> confirmedQuery = eventRegistrantsRef.whereEqualTo(dbm.eventStatusKey, DBManager.RegistrantStatus.CONFIRMED).get();
+
+        // combine results
+        Tasks.whenAllComplete(selectedQuery, confirmedQuery).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                int selectedCount = selectedQuery.getResult().size();
+                int confirmedCount = confirmedQuery.getResult().size();
+                onSuccessCallback.run(selectedCount + confirmedCount);
+            } else {
+                Log.e("Firestore", "Error counting selected and confirmed: ", task.getException());
+            }
+        });
     }
 }

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
@@ -3,7 +3,6 @@ package com.example.pickme_nebula0.organizer;
 import android.util.Log;
 
 import com.example.pickme_nebula0.db.DBManager;
-import com.example.pickme_nebula0.db.DBManagerStatic;
 import com.example.pickme_nebula0.entrant.EntrantRole;
 import com.example.pickme_nebula0.event.Event;
 import com.example.pickme_nebula0.user.User;
@@ -28,6 +27,7 @@ public class OrganizerRole extends User {
     private static String usersSelectedKey = "selected";
     private static String usersNotSelectedKey = "not selected";
     private static String organizer_tag = "OrganizerRole";
+    private static DBManager dbm = new DBManager();
 
     /**
      * Constructor
@@ -299,8 +299,8 @@ public class OrganizerRole extends User {
     // US 02.07.02 As an organizer I want to send notifications to all selected entrants
     // US 02.07.03 As an organizer I want to send a notification to all canceled entrants
 
-    public boolean notifyEntrantsByStatus(String eventID, String title, String message, DBManagerStatic.RegistrantStatus status) {
-        DBManagerStatic.notifyEntrantsOfStatus(title, message, eventID, status);
+    public boolean notifyEntrantsByStatus(String eventID, String title, String message, DBManager.RegistrantStatus status) {
+        dbm.notifyEntrantsOfStatus(title, message, eventID, status);
         return true;
     }
 
@@ -313,7 +313,7 @@ public class OrganizerRole extends User {
         if (!user.getNotificationsEnabled()) {return false;}
         String title = "Selected For Event";
         String message = "You have been selected to join the following event: " + event.getEventName();
-        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        dbm.createNotification(title, message, user.getUserID(), event.getEventID());
         return true;
     }
 
@@ -321,7 +321,7 @@ public class OrganizerRole extends User {
         if (!user.getNotificationsEnabled()) {return false;}
         String title = "Selected For Event";
         String message = "You have been selected to join the following event, since some have declined their invite: " + event.getEventName();
-        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        dbm.createNotification(title, message, user.getUserID(), event.getEventID());
         return true;
     }
 
@@ -329,7 +329,7 @@ public class OrganizerRole extends User {
         if (!user.getNotificationsEnabled()) {return false;}
         String title = "Not Selected For Event";
         String message = "You have not been sampled for the following event, but you will remain waitlisted in case a spot opens up: " + event.getEventName();
-        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        dbm.createNotification(title, message, user.getUserID(), event.getEventID());
         return true;
     }
 
@@ -337,13 +337,13 @@ public class OrganizerRole extends User {
         if (!user.getNotificationsEnabled()) {return false;}
         String title = "Cancelled Event Invite";
         String message = "Your invitation to join the following event has been cancelled: " + event.getEventName();
-        DBManagerStatic.createNotification(title, message, user.getUserID(), event.getEventID());
+        dbm.createNotification(title, message, user.getUserID(), event.getEventID());
         return true;
     }
 
     // -------------- UTILITY FUNCTIONS
-    public static void sampledEntrantsExist(String eventID, DBManagerStatic.Void2VoidCallback entrantsExistCallback, DBManagerStatic.Void2VoidCallback entrantsNotExistCallback) {
-        DBManager dbm = new DBManager();
+    public static void sampledEntrantsExist(String eventID, DBManager.Void2VoidCallback entrantsExistCallback, DBManager.Void2VoidCallback entrantsNotExistCallback) {
+//        DBManager dbm = new DBManager();
         CollectionReference eventRegistrantsRef = dbm.db.collection(dbm.eventsCollection)
                 .document(eventID)
                 .collection(dbm.eventRegistrantsCollection);
@@ -365,8 +365,8 @@ public class OrganizerRole extends User {
     }
 
     // for resampling users
-    private static void countConfirmedAndSelected(String eventID, DBManagerStatic.Obj2VoidCallback onSuccessCallback) {
-        DBManager dbm = new DBManager();
+    private static void countConfirmedAndSelected(String eventID, DBManager.Obj2VoidCallback onSuccessCallback) {
+//        DBManager dbm = new DBManager();
         // reference to EventRegistrants subcollection
         CollectionReference eventRegistrantsRef = dbm.db.collection(dbm.eventsCollection)
                 .document(eventID)

--- a/app/PickMe_nebula0/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/PickMe_nebula0/app/src/main/res/layout/activity_event_detail.xml
@@ -45,13 +45,29 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="24dp" />
 
-    <Button
-        android:id="@+id/button_ed_msgEntrants"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Message Entrants"
+        android:layout_margin="0dp"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent">
+
+        <Button
+            android:id="@+id/button_ed_msgEntrants"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="10dp"
+            android:text="Message Entrants" />
+
+        <Button
+            android:id="@+id/button_sample_entrants"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_weight="1"
+            android:text="Sample Entrants" />
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Organizer event details screen includes option to sample entrants and notify those who were selected and those who weren't. If entrant statuses change from SELECTED to CONFIRMED or CANCELLED, then entrants who weren't initially chosen can be resampled to fill the empty spots.

Covers the following user stories (as of 11-20):
- US 02.05.01 As an organizer I want to send a notification to chosen entrants to sign up for events.
- US 02.05.02 As an organizer I want to set the system to sample a specified number of attendees to register for the event
- US 02.05.03 As an organizer I want to be able to draw a replacement applicant from the pooling system when a previously selected applicant cancels or rejects the invitation

Tested as follows:
- create 12 new test users and add all to an event waitlist
- check database and list of waitlisted entrants on UI
- through the UI, sample entrants
- check database and list of selected entrants on UI
- check notification documents are generated correctly
- move some entrants to confirmed or cancelled (update their user doc and corresponding event doc)
- resample through the UI
- check log, UI list of entrants by status, database

