### PR TITLE
updated qr code test with updated name of qr code manager

### DIFF
--- a/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/QRcodeTest.java
+++ b/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/QRcodeTest.java
@@ -5,29 +5,27 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
 import com.example.pickme_nebula0.qr.QRCodeActivity;
+import com.example.pickme_nebula0.qr.QRCodeGenerator;
 import com.example.pickme_nebula0.qr.QRCodeManager;
 import org.junit.Test;
 
 public class QRcodeTest {
+QRCodeGenerator QRTester = new QRCodeGenerator();
 
     public void TestURIgen(){
-        QRCodeManager Test=new QRCodeManager();
-
-        String TestURI=Test.generateQRCodeURI("hello");
-        assert("PickMe://event/hello"== TestURI);
+        String TestURI=QRTester.generateQRCodeURI("hello");
+        assert("PickMe://event/hello".equals(TestURI));
 
     }
     public void TestQRcodegen(){
-
-        QRCodeManager Test=new QRCodeManager();
-     assert(Test.generateQRCodeBitmap("PickMe://event/hello") instanceof Bitmap);
-
+        Bitmap bitmap = QRTester.generateQRCodeBitmap("PickMe://event/hello");
+        assert(bitmap != null);
+        // if passes null assertion, bitmap is an instance of Bitmap
     }
 
     public void TestturntoBase64(){
-        QRCodeManager Test=new QRCodeManager();
         Bitmap testbitmap=Bitmap.createBitmap(12,16, Bitmap.Config.ARGB_8888);
-       assert( Test.bitmapToBase64(testbitmap) instanceof String);
+       assert(QRTester.bitmapToBase64(testbitmap) instanceof String);
     }
 
 }

--- a/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/QRcodeTest.java
+++ b/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/QRcodeTest.java
@@ -6,7 +6,6 @@ import android.graphics.BitmapFactory;
 
 import com.example.pickme_nebula0.qr.QRCodeActivity;
 import com.example.pickme_nebula0.qr.QRCodeGenerator;
-import com.example.pickme_nebula0.qr.QRCodeManager;
 import org.junit.Test;
 
 public class QRcodeTest {


### PR DESCRIPTION
I accidentally merged a previous version of this branch without testing, and it turns out that it references QRCodeManager which has been renamed to QRCodeGenerator. Because I merged it, it was causing other unrelated PR builds to fail, so I quickly fixed it in this PR.