### PR TITLE
List Duplication Bugfix

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -316,6 +316,20 @@ as a QR code doesn't exist on its own  aslo a change made to the QR code
             QRAdapter.notifyDataSetChanged();
         }, () -> Log.d(this.getClass().getSimpleName(), "Failed to update QR code list"));
 
+//        events.clear();
+//        QRAdapter.notifyDataSetChanged();
+//        db.collection("Events")
+//                .get()
+//                .addOnCompleteListener(task -> {
+//                    if (task.isSuccessful()) {
+//                        for (QueryDocumentSnapshot document : task.getResult()) {
+//                            Event e = document.toObject(Event.class);
+//                            events.add(e);
+//                        }
+//                        QRAdapter.notifyDataSetChanged();
+//                    }
+//                });
+
     }
 
     private void updateFacilities(){

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -38,6 +38,7 @@ import com.google.firebase.firestore.QueryDocumentSnapshot;
 
 import org.checkerframework.framework.qual.DefaultQualifier;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -250,19 +251,26 @@ public class AdminHomeActivity extends AppCompatActivity {
     }
 
     private void updateEvents(){
-        events.clear();
-        eventAdapter.notifyDataSetChanged();
-        db.collection("Events")
-                .get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        for (QueryDocumentSnapshot document : task.getResult()) {
-                            Event e = document.toObject(Event.class);
-                            events.add(e);
-                        }
-                        eventAdapter.notifyDataSetChanged();
-                    }
-                });
+        EventManager.get_all_events((eventsObj) -> {
+            ArrayList<Event> fetched_events = (ArrayList<Event>) eventsObj;
+            events.clear();
+            events.addAll(fetched_events);
+            eventAdapter.notifyDataSetChanged();
+
+        }, () -> {});
+//        events.clear();
+//        eventAdapter.notifyDataSetChanged();
+//        db.collection("Events")
+//                .get()
+//                .addOnCompleteListener(task -> {
+//                    if (task.isSuccessful()) {
+//                        for (QueryDocumentSnapshot document : task.getResult()) {
+//                            Event e = document.toObject(Event.class);
+//                            events.add(e);
+//                        }
+//                        eventAdapter.notifyDataSetChanged();
+//                    }
+//                });
     }
 
     private void updateProfiles(){

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -20,6 +20,7 @@ import com.example.pickme_nebula0.DeviceManager;
 import com.example.pickme_nebula0.R;
 import com.example.pickme_nebula0.event.Event;
 import com.example.pickme_nebula0.event.EventDetailUserActivity;
+import com.example.pickme_nebula0.event.EventManager;
 import com.example.pickme_nebula0.event.EventsArrayAdapter;
 import com.example.pickme_nebula0.facility.Facility;
 import com.example.pickme_nebula0.facility.FacilityArrayAdapter;
@@ -301,19 +302,20 @@ as a QR code doesn't exist on its own  aslo a change made to the QR code
  */
     private void updateQRCodes(){
 
-        events.clear();
-        QRAdapter.notifyDataSetChanged();
-        db.collection("Events")
-                .get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        for (QueryDocumentSnapshot document : task.getResult()) {
-                               Event e = document.toObject(Event.class);
-                                events.add(e);
-                        }
-                        QRAdapter.notifyDataSetChanged();
-                    }
-                });
+        EventManager.get_all_events((eventsObj) -> {
+            ArrayList<Event> fetched_events = (ArrayList<Event>) eventsObj;
+            events.clear();
+
+            // only add qr code to list if its data exists
+            for (Event event: fetched_events) {
+                String qr_code_data = event.getQrCodeData();
+                if (qr_code_data == null || qr_code_data.equals("null")) { continue; }
+                events.add(event);
+            }
+
+            QRAdapter.notifyDataSetChanged();
+        }, () -> Log.d(this.getClass().getSimpleName(), "Failed to update QR code list"));
+
     }
 
     private void updateFacilities(){

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
@@ -2,8 +2,15 @@ package com.example.pickme_nebula0.event;
 
 import android.util.Log;
 
+import androidx.annotation.Nullable;
+
 import com.example.pickme_nebula0.db.DBManager;
 import com.example.pickme_nebula0.user.User;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,8 +18,17 @@ import java.util.List;
 // static class for Event-related DB functionality
 public class EventManager {
     private static DBManager dbm = new DBManager();
+    private static FirebaseFirestore db = dbm.db;
     private static String event_manager_tag = "EventManager";
 
+    /**
+     * Checks if the waitlist of a given event is full.
+     * Runs a success callback if not full, and a failure callback if full.
+     * Use this when a user attempts to register for an event.
+     * @param eventID
+     * @param waitlistNotFullCallback
+     * @param waitlistFullCallback
+     */
     public static void waitlist_full(String eventID, DBManager.Void2VoidCallback waitlistNotFullCallback, DBManager.Void2VoidCallback waitlistFullCallback) {
         dbm.getEvent(eventID, (eventObj) -> {
             Event event = (Event) eventObj;
@@ -40,4 +56,40 @@ public class EventManager {
 
         }, () -> { Log.d(event_manager_tag, "Failed to fetch event to check waitlist capacity"); });
     }
+
+
+    /**
+     * For admin to fetch a list of all existing events
+     * Passes list of events (arraylist typecasted as Object)
+     * to callback if successful,
+     * otherwise runs failure callback.
+     *
+     * @param onSuccessCallback
+     * @param onFailureCallback
+     */
+    public static void get_all_events(DBManager.Obj2VoidCallback onSuccessCallback, DBManager.Void2VoidCallback onFailureCallback) {
+        db.collection(dbm.eventsCollection)
+                .addSnapshotListener(new EventListener<QuerySnapshot>() {
+                    @Override
+                    public void onEvent(@Nullable QuerySnapshot querySnapshots, @Nullable FirebaseFirestoreException error) {
+                        if (error != null) {
+                            Log.e(event_manager_tag, error.toString());
+                            onFailureCallback.run();
+                        }
+
+                        if (querySnapshots != null) {
+                            // fetch all hashed qr codes and pass to on success callback
+                            ArrayList<Event> events = new ArrayList<>();
+                            for (QueryDocumentSnapshot doc : querySnapshots) {
+                                Event e = doc.toObject(Event.class);
+                                events.add(e);
+                            }
+                            Log.d(event_manager_tag, String.format("Fetched %d events", events.size()));
+                            onSuccessCallback.run(events);
+                        }
+                    }
+                });
+    }
+
+
 }

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
@@ -21,6 +21,10 @@ public class EventManager {
     private static FirebaseFirestore db = dbm.db;
     private static String event_manager_tag = "EventManager";
 
+    public enum EventStatus {
+        PAST, ONGOING
+    }
+
     /**
      * Checks if the waitlist of a given event is full.
      * Runs a success callback if not full, and a failure callback if full.

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/fragments/OrganizerOngoingFragment.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/fragments/OrganizerOngoingFragment.java
@@ -2,6 +2,7 @@ package com.example.pickme_nebula0.organizer.fragments;
 
 import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,10 +14,13 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.pickme_nebula0.DeviceManager;
 import com.example.pickme_nebula0.R;
 import com.example.pickme_nebula0.event.Event;
+import com.example.pickme_nebula0.event.EventManager;
+import com.example.pickme_nebula0.organizer.OrganizerRole;
 import com.example.pickme_nebula0.organizer.adapters.OngoingEventsAdapter;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Date;
 
@@ -51,20 +55,27 @@ public class OrganizerOngoingFragment extends Fragment {
 
     @SuppressLint("NotifyDataSetChanged")
     private void loadOngoingEvents() {
-        ongoingEvents.clear();
-        db.collection("Events")
-                .whereEqualTo("organizerID", DeviceManager.getDeviceId())
-                .get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        for (QueryDocumentSnapshot document : task.getResult()) {
-                            Event event = document.toObject(Event.class);
-                            if (event.getEventDate() != null && !event.getEventDate().before(new Date())) {
-                                ongoingEvents.add(event);
-                            }
-                        }
-                        adapter.notifyDataSetChanged();
-                    }
-                });
+        OrganizerRole.get_event_by_status(DeviceManager.getDeviceId(), EventManager.EventStatus.ONGOING, (ongoingEventsObj) -> {
+            ArrayList<Event> events = (ArrayList<Event>) ongoingEventsObj;
+
+            ongoingEvents.clear();
+            ongoingEvents.addAll(events);
+            adapter.notifyDataSetChanged();
+        }, () -> Log.d(this.getClass().getSimpleName(), "Could not load ongoing events"));
+//        ongoingEvents.clear();
+//        db.collection("Events")
+//                .whereEqualTo("organizerID", DeviceManager.getDeviceId())
+//                .get()
+//                .addOnCompleteListener(task -> {
+//                    if (task.isSuccessful()) {
+//                        for (QueryDocumentSnapshot document : task.getResult()) {
+//                            Event event = document.toObject(Event.class);
+//                            if (event.getEventDate() != null && !event.getEventDate().before(new Date())) {
+//                                ongoingEvents.add(event);
+//                            }
+//                        }
+//                        adapter.notifyDataSetChanged();
+//                    }
+//                });
     }
 }

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/fragments/OrganizerPastFragment.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/fragments/OrganizerPastFragment.java
@@ -14,6 +14,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.example.pickme_nebula0.DeviceManager;
 import com.example.pickme_nebula0.R;
 import com.example.pickme_nebula0.event.Event;
+import com.example.pickme_nebula0.event.EventManager;
+import com.example.pickme_nebula0.organizer.OrganizerRole;
 import com.example.pickme_nebula0.organizer.adapters.PastEventsAdapter;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
@@ -52,20 +54,29 @@ public class OrganizerPastFragment extends Fragment {
 
     @SuppressLint("NotifyDataSetChanged")
     private void loadPastEvents() {
-        pastEvents.clear();
-        db.collection("Events")
-                .whereEqualTo("organizerID", DeviceManager.getDeviceId())
-                .get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        for (QueryDocumentSnapshot document : task.getResult()) {
-                            Event event = document.toObject(Event.class);
-                            if (event.getEventDate() != null && event.getEventDate().before(new Date())) {
-                                pastEvents.add(event);
-                            }
-                        }
-                        adapter.notifyDataSetChanged();
-                    }
-                });
+        OrganizerRole.get_event_by_status(DeviceManager.getDeviceId(), EventManager.EventStatus.PAST, (pastEventsObj) -> {
+            ArrayList<Event> events = (ArrayList<Event>) pastEventsObj;
+
+            pastEvents.clear();
+            pastEvents.addAll(events);
+            adapter.notifyDataSetChanged();
+        }, () -> Log.d(this.getClass().getSimpleName(), "Could not load past events"));
+
+
+//        pastEvents.clear();
+//        db.collection("Events")
+//                .whereEqualTo("organizerID", DeviceManager.getDeviceId())
+//                .get()
+//                .addOnCompleteListener(task -> {
+//                    if (task.isSuccessful()) {
+//                        for (QueryDocumentSnapshot document : task.getResult()) {
+//                            Event event = document.toObject(Event.class);
+//                            if (event.getEventDate() != null && event.getEventDate().before(new Date())) {
+//                                pastEvents.add(event);
+//                            }
+//                        }
+//                        adapter.notifyDataSetChanged();
+//                    }
+//                });
     }
 }

--- a/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/OrganizerManageEntrantsTest.java
+++ b/app/PickMe_nebula0/app/src/test/java/com/example/pickme_nebula0/OrganizerManageEntrantsTest.java
@@ -1,2 +1,0 @@
-package com.example.pickme_nebula0;public class OrganizerManageEntrantsTest {
-}


### PR DESCRIPTION
The following lists have duplicate items fixed:
- admin view of qr codes; only shows if qr code data is not null
- admin view of all events
- organizer view of past and ongoing events

List population for the lists above has been refactored and fixed using onSnapshotListener. This allows changes to the database to show up in real time without accidentally notifying the adapter before all items have been fetched.

The following admin view lists were not refactored because they seem to be fine with no duplicates (however, this may be due to their size):
- updateProfiles
- updateImages
- updateFacilities