### PR TITLE
adapters no longer use same list

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -343,7 +343,6 @@ as a QR code doesn't exist on its own  aslo a change made to the QR code
 
         EventManager.get_all_events((eventsObj) -> {
             ArrayList<Event> fetched_events = (ArrayList<Event>) eventsObj;
-<<<<<<< HEAD
             eventsWithQR.clear();
 
             // only add qr code to list if its data exists
@@ -353,21 +352,6 @@ as a QR code doesn't exist on its own  aslo a change made to the QR code
                 eventsWithQR.add(event);
             }
             QRAdapter.notifyDataSetChanged();
-=======
-            runOnUiThread(() -> {
-                events.clear();
-
-                for (Event event: fetched_events) {
-                    // only add qr code to list if its data exists
-                    String qr_code_data = event.getQrCodeData();
-                    if (qr_code_data == null || qr_code_data.equals("null")) { continue; }
-                    events.add(event);
-                }
-
-                QRAdapter.notifyDataSetChanged();
-            });
-
->>>>>>> origin/main
         }, () -> Log.d(this.getClass().getSimpleName(), "Failed to update QR code list"));
 
 //        events.clear();

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -166,6 +166,9 @@ public class AdminHomeActivity extends AppCompatActivity {
             Toast.makeText(AdminHomeActivity.this, "Switched to Manage Events layout", Toast.LENGTH_SHORT).show();
         });
 
+        // sets up interaction with first visible layout, ie. the manage events layout
+        btnManageEvents.performClick();
+
         btnManageUsers.setOnClickListener(v -> {
             viewFlipper.setDisplayedChild(1); // Show Manage Profile layout
             updateProfiles();

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/AdminHomeActivity.java
@@ -14,6 +14,7 @@ import android.widget.ListView;
 import android.widget.Toast;
 import android.widget.ViewFlipper;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.pickme_nebula0.DeviceManager;
@@ -33,13 +34,17 @@ import com.example.pickme_nebula0.qr.QRcodeAdapter;
 import com.example.pickme_nebula0.user.User;
 import com.example.pickme_nebula0.user.UserArrayAdapter;
 import com.example.pickme_nebula0.user.activities.UserDetailActivity;
+import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import org.checkerframework.framework.qual.DefaultQualifier;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -61,8 +66,11 @@ public class AdminHomeActivity extends AppCompatActivity {
     private ArrayList<User> users;
     private ListView usersList;
 
+    private ArrayList<Event> eventsWithImage;
     private ListView imagesList;
     private ImageAdapter imageAdapter;
+
+    private ArrayList<Event> eventsWithQR;
     private ListView QRcodesList;
     private QRcodeAdapter QRAdapter;
 
@@ -123,12 +131,16 @@ public class AdminHomeActivity extends AppCompatActivity {
         facilityAdapter = new FacilityArrayAdapter(AdminHomeActivity.this,R.id.item_facility, facilities);
         facilitiesList.setAdapter(facilityAdapter);
 
+        // for images
+        eventsWithImage = new ArrayList<>();
         imagesList=findViewById(R.id.ImageListView);
-        imageAdapter=new ImageAdapter(AdminHomeActivity.this,R.id.item_image, events);
+        imageAdapter=new ImageAdapter(AdminHomeActivity.this,R.id.item_image, eventsWithImage);
         imagesList.setAdapter(imageAdapter);
+
        // for QR codes
+        eventsWithQR = new ArrayList<>();
         QRcodesList=findViewById(R.id.QRcodeListView);
-        QRAdapter=new QRcodeAdapter(AdminHomeActivity.this,R.id.item_qrcode, events);
+        QRAdapter=new QRcodeAdapter(AdminHomeActivity.this,R.id.item_qrcode, eventsWithQR);
         QRcodesList.setAdapter(QRAdapter);
 
         btnBack.setOnClickListener(v -> finish());
@@ -291,20 +303,32 @@ public class AdminHomeActivity extends AppCompatActivity {
                 });
     }
 
-    private void updateImages(){
-        events.clear();
+    private void updateImages() {
+        eventsWithImage.clear();
         imageAdapter.notifyDataSetChanged();
+
         db.collection("Events")
-                .get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        for (QueryDocumentSnapshot document : task.getResult()) {
-                            Event e = document.toObject(Event.class);
-                            events.add(e);
-                        }
-                        imageAdapter.notifyDataSetChanged();
+            .addSnapshotListener(new EventListener<QuerySnapshot>() {
+                @Override
+                public void onEvent(@Nullable QuerySnapshot querySnapshots, @Nullable FirebaseFirestoreException error) {
+                    if (error != null || querySnapshots == null) {
+                        Log.w("AdminHomeActivity", "Listen failed.", error);
+                        return;
                     }
-                });
+
+                    eventsWithImage.clear();
+                    // check if each fetched event has a non null image
+                    for (QueryDocumentSnapshot doc : querySnapshots) {
+                        if (doc == null) { continue; }
+                        if (doc.contains("poster") && doc.get("poster") != null) {
+                            Event event = doc.toObject(Event.class);
+                            eventsWithImage.add(event);
+                        }
+                    }
+
+                    imageAdapter.notifyDataSetChanged();
+                }
+            });
     }
 /*
 there is no reason to separate the QR codes from their respective event
@@ -314,15 +338,14 @@ as a QR code doesn't exist on its own  aslo a change made to the QR code
 
         EventManager.get_all_events((eventsObj) -> {
             ArrayList<Event> fetched_events = (ArrayList<Event>) eventsObj;
-            events.clear();
+            eventsWithQR.clear();
 
             // only add qr code to list if its data exists
             for (Event event: fetched_events) {
                 String qr_code_data = event.getQrCodeData();
                 if (qr_code_data == null || qr_code_data.equals("null")) { continue; }
-                events.add(event);
+                eventsWithQR.add(event);
             }
-
             QRAdapter.notifyDataSetChanged();
         }, () -> Log.d(this.getClass().getSimpleName(), "Failed to update QR code list"));
 


### PR DESCRIPTION
The adapters for displaying all qr codes and images used to be attached to the same event list. However, because all 3 adapters use the same list but only call `notifyDataSetChanged` on their own adapters, this was causing the following error:
>The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. Make sure your adapter calls notifyDataSetChanged() when its content changes.

The qr code and image adapters have their own event lists now. This ensures that we only display events for which a qr code or image exists, without having to display null values for the sake of using the same events list. Their respective lists are subsets of all events.

Tested and everything works.