### PR TITLE
Image Deletion

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/EventDetailAdminActivity.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/admin/activities/EventDetailAdminActivity.java
@@ -1,6 +1,7 @@
 package com.example.pickme_nebula0.admin.activities;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 import android.widget.Button;
@@ -13,7 +14,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.bumptech.glide.Glide;
 import com.example.pickme_nebula0.R;
 import com.example.pickme_nebula0.db.DBManager;
+import com.example.pickme_nebula0.db.FBStorageManager;
 import com.example.pickme_nebula0.event.Event;
+import com.example.pickme_nebula0.event.EventManager;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.squareup.picasso.Picasso;
@@ -67,7 +70,19 @@ public class EventDetailAdminActivity extends AppCompatActivity {
         delImageBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                deleteImageFromFirebase(eventID);
+                EventManager.removePoster(eventID, () -> {
+                    // poster removed from storage and event doc
+                    Toast.makeText(EventDetailAdminActivity.this, "Image Deleted", Toast.LENGTH_SHORT).show();
+                    imageView.setVisibility(View.GONE);
+                    delImageBtn.setVisibility(View.GONE);
+                }, () -> {
+                    // poster could not be removed
+                    Toast.makeText(EventDetailAdminActivity.this, "Failed to delete image", Toast.LENGTH_LONG).show();
+                    imageView.setVisibility(View.GONE);
+                    delImageBtn.setVisibility(View.GONE);
+                });
+
+//                deleteImageFromFirebase(eventID);
                 finish();
             }
         });
@@ -211,22 +226,30 @@ public class EventDetailAdminActivity extends AppCompatActivity {
     }
 
     private void loadImageFromFirebase(String eventID) {
-        // Initialize FirebaseStorage with the correct bucket URL
-        FirebaseStorage storage = FirebaseStorage.getInstance("gs://pickme-c2fb3.firebasestorage.app");
-        storageRef = storage.getReference();
-        // TODO: FIX THE PATH ACCORDINGLY
-        StorageReference imageRef = storageRef.child("eventPosters/" + eventID + ".jpg");
-
-        imageRef.getDownloadUrl().addOnSuccessListener(uri -> {
-            // Load the image using Picasso
+        FBStorageManager.eventPosterExists(eventID, (uri) -> {
             Picasso.get()
                     .load(uri)
                     .into(imageView);
-        }).addOnFailureListener(exception -> {
-            // Handle any errors
-            Toast.makeText(EventDetailAdminActivity.this, "Failed to load image: " + exception.getMessage(), Toast.LENGTH_LONG).show();
+        }, (error_message) -> {
+            Toast.makeText(EventDetailAdminActivity.this, "Failed to load image: "+error_message, Toast.LENGTH_LONG).show();
             imageView.setVisibility(View.GONE);
         });
+//        // Initialize FirebaseStorage with the correct bucket URL
+//        FirebaseStorage storage = FirebaseStorage.getInstance("gs://pickme-c2fb3.firebasestorage.app");
+//        storageRef = storage.getReference();
+//        // TODO: FIX THE PATH ACCORDINGLY
+//        StorageReference imageRef = storageRef.child("eventPosters/" + eventID + ".jpg");
+//
+//        imageRef.getDownloadUrl().addOnSuccessListener(uri -> {
+//            // Load the image using Picasso
+//            Picasso.get()
+//                    .load(uri)
+//                    .into(imageView);
+//        }).addOnFailureListener(exception -> {
+//            // Handle any errors
+//            Toast.makeText(EventDetailAdminActivity.this, "Failed to load image: " + exception.getMessage(), Toast.LENGTH_LONG).show();
+//            imageView.setVisibility(View.GONE);
+//        });
     }
 
     private void deleteImageFromFirebase(String eventID) {

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/FBStorageManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/db/FBStorageManager.java
@@ -5,15 +5,23 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.provider.ContactsContract;
+import android.util.Log;
+import android.view.View;
 import android.widget.Toast;
 import android.Manifest;
+
+import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import com.example.pickme_nebula0.DeviceManager;
 import com.example.pickme_nebula0.SharedDialogue;
+import com.example.pickme_nebula0.admin.activities.EventDetailAdminActivity;
 import com.example.pickme_nebula0.event.Event;
+import com.example.pickme_nebula0.event.EventManager;
 import com.example.pickme_nebula0.user.User;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
@@ -23,6 +31,16 @@ import com.squareup.picasso.Picasso;
 import java.io.File;
 
 public class FBStorageManager {
+
+    public static final String firebaseStorageImageBucket = "gs://pickme-c2fb3.firebasestorage.app";
+    public static final String eventPosterFieldName = "poster";
+    public static final String eventPosterImageDirectory = "eventPosters/";
+
+    public static final String profilePicFieldName = "profilePic";
+    public static final String profilePicImageDirectory = "profilePics/";
+
+    private static final String storage_tag = "FBStorageManager";
+
     public interface Uri2VoidCallback {
         void run(Uri uri);
     }
@@ -101,6 +119,98 @@ public class FBStorageManager {
             }
 
         }, onFailureCallback);
+    }
+
+
+    /**
+     * Removes event poster from Firebase Storage.
+     * Updating event docs should be done from another function,
+     * and is implemented in EventManager.
+     *
+     * @param eventID
+     * @param onSuccessCallback
+     * @param onFailureCallback
+     * @see EventManager
+     */
+    public static void deleteEventPosterFromStorage(String eventID, DBManager.Void2VoidCallback onSuccessCallback, DBManager.Void2VoidCallback onFailureCallback) {
+
+        eventPosterExists(eventID, (uri) -> {
+            // assumes lastPathSegment will return the storage path
+            String storagePath = uri.getLastPathSegment();
+            if (storagePath == null || storagePath.isEmpty()) {
+                onFailureCallback.run();
+            }
+
+            Log.d(storage_tag, "Delete event poster at the following path: "+storagePath);
+
+            StorageReference imageRef = storageRef.child(storagePath);
+            imageRef.delete().addOnSuccessListener(aVoid -> {
+                onSuccessCallback.run();
+            }).addOnFailureListener(exception -> {
+                onFailureCallback.run();
+            });
+
+        }, (error_message) -> {onFailureCallback.run();});
+    }
+
+    // utility functions
+
+    /**
+     * Assumes event poster path is here: eventPosters/{eventID}
+     * There is no method for checking if a StorageReference exists,
+     * so a workaround is to try downloading the URL
+     * and assume a failure means the reference doesn't exist.
+     * @param eventID
+     * @param posterFoundCallback
+     * @param posterNotFoundCallback
+     */
+    public static void eventPosterExists(String eventID, Uri2VoidCallback posterFoundCallback, EventManager.String2VoidCallback posterNotFoundCallback) {
+
+        // TODO: replace path with consistent formatting
+        String storagePath = "eventPosters/"+eventID;
+        imageExists(storagePath, posterFoundCallback, posterNotFoundCallback);
+    }
+
+    public static void profilePicExists(String userID, Uri2VoidCallback picFoundCallback, EventManager.String2VoidCallback picNotFoundCallback) {
+
+        String storagePath = "profilePics/" + userID;
+        imageExists(storagePath, picFoundCallback, picNotFoundCallback);
+    }
+
+    public static void imageExists(String storagePath, Uri2VoidCallback posterFoundCallback, EventManager.String2VoidCallback posterNotFoundCallback) {
+
+        // TODO: replace path with consistent formatting
+        StorageReference imageRef = storageRef.child(storagePath);
+
+        imageRef.getDownloadUrl().addOnSuccessListener(new OnSuccessListener<Uri>() {
+            @Override
+            public void onSuccess(Uri uri) {
+                // Got the download URL for 'users/me/profile.png'
+                Log.d(storage_tag, uri.toString());
+                posterFoundCallback.run(uri);
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception exception) {
+                // Handle any errors
+                Log.d(storage_tag, "no uri found at "+storagePath);
+                posterNotFoundCallback.run("Could not get download URL");
+            }
+        });
+    }
+
+    /**
+     * To standardize format of image paths, for uploading user profile pic
+     * and event poster.
+     * Adds .jpg file extension and names image based on eventID or userID.
+     *
+     * @param imagesDirectory
+     * @param objectID
+     * @return
+     */
+    public static String formatImagePath(String imagesDirectory, String objectID) {
+        assert imagesDirectory.endsWith("/");
+        return String.format("%s%s.jpg", imagesDirectory, objectID);
     }
 
     }

--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/event/EventManager.java
@@ -1,13 +1,19 @@
 package com.example.pickme_nebula0.event;
 
+import static com.example.pickme_nebula0.db.FBStorageManager.eventPosterFieldName;
+
+import android.net.Uri;
 import android.util.Log;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.example.pickme_nebula0.db.DBManager;
 import com.example.pickme_nebula0.db.FBStorageManager;
 import com.example.pickme_nebula0.user.User;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -16,6 +22,8 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -307,6 +315,7 @@ public class EventManager {
 
 
     /**
+     * Searches event poster attribute.
      * Passes the poster URI to callback if it exists for a given event.
      * Otherwise, runs posterNotFound callback.
      * Use for admin poster viewing.
@@ -320,7 +329,7 @@ public class EventManager {
      */
     public static void event_has_poster(String eventID, String2VoidCallback posterFoundCallback, String2VoidCallback posterNotFoundCallback) {
         DocumentReference eventDoc = db.collection(dbm.eventsCollection).document(eventID);
-        String event_poster_field = "poster";   // TODO: add this as static attribute for FBManager
+        String event_poster_field = eventPosterFieldName;
 
         eventDoc.get().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
@@ -344,5 +353,17 @@ public class EventManager {
         });
 
     }
+
+
+    public static void removePoster(String eventID, DBManager.Void2VoidCallback onSuccessCallback, DBManager.Void2VoidCallback onFailureCallback) {
+        FBStorageManager.deleteEventPosterFromStorage(eventID, () -> {
+            // removed poster from storage
+            // update event docs
+            DocumentReference eventDocRef = db.collection(dbm.eventsCollection).document(eventID);
+            dbm.updateField(eventDocRef, eventPosterFieldName, null);
+
+        }, onFailureCallback);
+    }
+
 }
 


### PR DESCRIPTION
- image deletion (from admin event view) will remove the image from storage and update the corresponding event doc's "poster" attribute to null
- added some helper functions to FBStorageManager to help with image deletion, including a method that checks if the poster exists, assuming its name corresponds to its event ID and has no file extension

Assumes that all event posters are stored in eventPosters/ and are named by their event ID.

TODO: any reads/writes to event posters or user profile pics should refer to the same storage paths.