### PR TITLE
changed getEventCapacity to getNumberOfAttendees

### DIFF
--- a/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
+++ b/app/PickMe_nebula0/app/src/main/java/com/example/pickme_nebula0/organizer/OrganizerRole.java
@@ -124,7 +124,7 @@ public class OrganizerRole extends User {
         // get waitlist capacity first via event
         dbManager.getEvent(eventID, (eventObj) -> {
             Event event = (Event) eventObj;
-            int eventCapacity = event.getEventCapacity();
+            int eventCapacity = event.getNumberOfAttendees();
 
             // get random sample of users
             sampleUsers(eventID, eventCapacity, (sampleResultsObj) -> {
@@ -170,7 +170,7 @@ public class OrganizerRole extends User {
         // get event capacity
         dbManager.getEvent(eventID, (eventObj) -> {
             Event event = (Event) eventObj;
-            int eventCapacity = event.getEventCapacity();
+            int eventCapacity = event.getNumberOfAttendees();
             if (eventCapacity == -1) {return;}
 
             // get number of entrants who are selected and confirmed


### PR DESCRIPTION
Event capacity seems to be some artifact from development and not in use, but the sampling functionality assumed that it contained the number of entrants to sample as opposed to number of attendees. This has been fixed.